### PR TITLE
add netrc setup

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -2,8 +2,6 @@ name: Generate SDK Docs
 on: 
   push:
     branches: ['main']
-  pull_request:
-    types: [reopened]
 
 jobs:
   build-docc:


### PR DESCRIPTION
Turns out we need a .netrc file to access our own binaries, which are needed to compile our DocC docs. 