### PR TITLE
Update hosting base path to account for public link

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -59,7 +59,7 @@ jobs:
         # collect the generated docarchive(s)
         cp -R $(find ${TMP_BUILDIR} -type d -name "*.doccarchive") "${DOCARCHIVE_DIR}/."
         # NOTE: this command seems to wipe out the path specified by --output-path, so use a tmp dir that you don't mind getting deleted (i.e. don't use _site as the output directory directly)
-        $(xcrun --find docc) process-archive transform-for-static-hosting "${DOCARCHIVE_DIR}/${SCHEME}.doccarchive" --hosting-base-path "/" --output-path "${PAGE_DIR}"
+        $(xcrun --find docc) process-archive transform-for-static-hosting "${DOCARCHIVE_DIR}/${SCHEME}.doccarchive" --hosting-base-path "hover-capture-ios" --output-path "${PAGE_DIR}"
 
         # Copy DocC Output to Jekyll Site
         mkdir -p _site/


### PR DESCRIPTION
When we were a private gh-page, our base path was just the root, since the URL was structured as `https://<unique-subdomain>.pages.github.io/<site>`. Once it was switched to public, the gh-pages URL became `https://hoverinc.github.io/hover-capture-ios/<site>`. This effectively means our base path changed from `/` to `hover-capture-ios`. More info [here](https://apple.github.io/swift-docc-plugin/documentation/swiftdoccplugin/publishing-to-github-pages/#Understanding-your-Projects-Configuration). Most likely the pages were blank (and not just 404's or something) since the base paths were incorrect, so the requested files in `index.html` were always not found.

This PR updates the `hosting-base-path` parameter to reflect the new public URL. 