### PR TITLE
update actions macos / xcode versions

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -21,7 +21,7 @@ jobs:
 
   build-docc:
     needs: build-jekyll
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 10
     permissions: read-all
     steps:
@@ -35,7 +35,7 @@ jobs:
           path: _site
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_15.0.1.app
+        run: sudo xcode-select -s /Applications/Xcode_16.app
 
       - name: Generate DocC docs
         run: |
@@ -96,7 +96,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     # Specify runner + deployment step
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 5
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
We've moved to using Xcode 16 for everything, so we should update this repo to use Xcode 16 for running its GitHub actions. 