### PR TITLE
sync download-artifact and upload-artifact versions

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Build Jekyll
         uses: actions/jekyll-build-pages@v1
       - name: Upload Jekyll Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: jekyll-site
           path: _site
@@ -29,7 +29,7 @@ jobs:
         with:
           lfs: 'true'
       - name: Download Jekyll Artifact
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4.1.8
         with:
           name: jekyll-site
           path: _site


### PR DESCRIPTION
The GitHub-pages site currently doesn't compile as the Jekyll site uploaded w/ the `upload-artifacts@3` action isn't compatible with the `download-artifact@4.1.7` action. This PR uses 2 versions of the respective actions that should work with each other. 