### PR TITLE
fix action deploy pages version

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -101,4 +101,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Fix compatibility issue of `actions/upload-pages-artifact@v3` with `actions/deploy-pages@v2` 
update to `actions/deploy-pages@v4`

https://github.com/actions/deploy-pages/issues/225