### PR TITLE
[SECENG-364] Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  commit-message:
+    prefix: "[bot] "
+  cooldown:
+    default-days: 7
+  schedule:
+    interval: "weekly"
+    day: "wednesday"
+    time: "11:00"
+    timezone: "America/Los_Angeles"

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           lfs: 'true'
       - name: Build Jekyll
-        uses: actions/jekyll-build-pages@v1
+        uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 # v1
       - name: Upload Jekyll Artifact
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: jekyll-site
           path: _site
@@ -25,11 +25,11 @@ jobs:
     timeout-minutes: 10
     permissions: read-all
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           lfs: 'true'
       - name: Download Jekyll Artifact
-        uses: actions/download-artifact@v4.1.8
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: jekyll-site
           path: _site
@@ -79,7 +79,7 @@ jobs:
           done
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
 
   # Deploy github pages job
   deploy:
@@ -101,4 +101,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
## Ticket
[SECENG-364](https://hoverinc.atlassian.net/browse/SECENG-364)

## Summary

Pin all external GitHub Actions to commit SHAs for supply chain security. Internal (hoverinc/) actions are left unpinned.

### Pinned Actions

  - `actions/checkout@v4` → [`34e11487`](https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5)
  - `actions/deploy-pages@v4` → [`d6db9016`](https://github.com/actions/deploy-pages/commit/d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e)
  - `actions/download-artifact@v4.1.8` → [`fa0a91b8`](https://github.com/actions/download-artifact/commit/fa0a91b85d4f404e444e00e005971372dc801d16)
  - `actions/jekyll-build-pages@v1` → [`44a6e6be`](https://github.com/actions/jekyll-build-pages/commit/44a6e6beabd48582f863aeeb6cb2151cc1716697)
  - `actions/upload-artifact@v4.4.0` → [`50769540`](https://github.com/actions/upload-artifact/commit/50769540e7f4bd5e21e526ee35c689e35e0d6874)
  - `actions/upload-pages-artifact@v3` → [`56afc609`](https://github.com/actions/upload-pages-artifact/commit/56afc609e74202658d3ffba0e8f6dda462b719fa)

### Dependabot

Added/updated `dependabot.yml` to keep GitHub Actions pinned to the latest SHA with a 7-day update cooldown.


[SECENG-364]: https://hoverinc.atlassian.net/browse/SECENG-364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ