### PR TITLE
[SECENG-364] Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     prefix: "[bot] "
   cooldown:
     default-days: 7
+    exclude:
+      - "hoverinc/*"
   schedule:
     interval: "weekly"
     day: "wednesday"

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: pr-automation
+on: pull_request
+
+jobs:
+  pr-automation:
+    uses: hoverinc/action-pr-automation/.github/workflows/pr-automation.yml@763fe363e0306d8495557e59c0a3b2a2e492aca8 # v1.1.0
+    secrets: inherit


### PR DESCRIPTION
## Ticket
[SECENG-364](https://hoverinc.atlassian.net/browse/SECENG-364)

## Summary


### Dependabot

Added/updated `dependabot.yml` to keep GitHub Actions pinned to the latest SHA with a 7-day update cooldown. `hoverinc/*` is excluded from the cooldown so internal actions can auto-merge promptly.

### PR Automation

Added `.github/workflows/pr-automation.yml` calling [`hoverinc/action-pr-automation`](https://github.com/hoverinc/action-pr-automation) to auto-merge safe dependabot PRs (dev deps and approved production deps).


[SECENG-364]: https://hoverinc.atlassian.net/browse/SECENG-364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ